### PR TITLE
fix: remove trailing comma in call args

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "NextcloudCapabilitiesKit",
-            targets: ["NextcloudCapabilitiesKit"],
+            targets: ["NextcloudCapabilitiesKit"]
         ),
     ],
     dependencies: [
@@ -34,5 +34,5 @@ let package = Package(
               .enableUpcomingFeature("StrictConcurrency")
             ]
         ),
-    ],
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,14 +24,14 @@ let package = Package(
         .target(
             name: "NextcloudCapabilitiesKit",
             swiftSettings: [
-              .enableUpcomingFeature("StrictConcurrency")
+                .enableUpcomingFeature("StrictConcurrency"),
             ]
         ),
         .testTarget(
             name: "NextcloudCapabilitiesKitTests",
             dependencies: ["NextcloudCapabilitiesKit"],
             swiftSettings: [
-              .enableUpcomingFeature("StrictConcurrency")
+                .enableUpcomingFeature("StrictConcurrency"),
             ]
         ),
     ]


### PR DESCRIPTION
saw some desktop client builds failing with:

```
xcodebuild: error: Could not resolve package dependencies:
  fatalError
  Unexpected ',' separator
  Unexpected ',' separator
  <unknown>:0: warning: legacy driver is now deprecated; consider avoiding specifying '-disallow-use-new-driver'
/Users/runner/Library/Developer/Xcode/DerivedData/NextcloudIntegration-dttfhlgecdrdchfiyiyqbdzvccqw/SourcePackages/checkouts/NextcloudCapabilitiesKit/Package.swift:16:9: error: unexpected ',' separator
14 |             name: "NextcloudCapabilitiesKit",
15 |             targets: ["NextcloudCapabilitiesKit"],
16 |         ),
   |         `- error: unexpected ',' separator
17 |     ],
18 |     dependencies: [

/Users/runner/Library/Developer/Xcode/DerivedData/NextcloudIntegration-dttfhlgecdrdchfiyiyqbdzvccqw/SourcePackages/checkouts/NextcloudCapabilitiesKit/Package.swift:38:1: error: unexpected ',' separator
36 |         ),
37 |     ],
38 | )
   | `- error: unexpected ',' separator
39 |
```